### PR TITLE
Configure user agent

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    richurls (0.5.6)
+    richurls (0.5.7)
       addressable (~> 2)
       oj (~> 3)
       ox (~> 2)

--- a/lib/richurls.rb
+++ b/lib/richurls.rb
@@ -7,6 +7,7 @@ require_relative 'url_fetcher'
 require_relative 'body_decorator'
 
 module RichUrls
+  DEFAULT_USER_AGENT = 'richurls'.freeze
   class MalformedURLError < StandardError; end
 
   def self.cache
@@ -20,6 +21,14 @@ module RichUrls
     end
 
     @cache ||= wrapper
+  end
+
+  def self.user_agent=(user_agent)
+    @user_agent ||= user_agent
+  end
+
+  def self.user_agent
+    @user_agent || DEFAULT_USER_AGENT
   end
 
   def self.enrich(url, filter: [], cache_time: nil)

--- a/lib/url_fetcher.rb
+++ b/lib/url_fetcher.rb
@@ -36,7 +36,13 @@ module RichUrls
     end
 
     def patron_call
-      session = Patron::Session.new(timeout: DEFAULT_TIMEOUT)
+      session = Patron::Session.new(
+        timeout: DEFAULT_TIMEOUT,
+        headers: {
+          'User-Agent' => RichUrls.user_agent
+        }
+      )
+
       response = session.get(@url)
 
       if response.status < 400

--- a/richurls.gemspec
+++ b/richurls.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name = 'richurls'
-  spec.version = '0.5.6'
+  spec.version = '0.5.7'
   spec.authors = ['grdw']
   spec.email = ['gerard@wetransfer.com']
 

--- a/spec/lib/rich_urls_spec.rb
+++ b/spec/lib/rich_urls_spec.rb
@@ -40,5 +40,11 @@ RSpec.describe RichUrls do
 
       expect(RichUrls.cache).to be_a(RichUrls::Cache::None)
     end
+
+    it 'sets a user agent' do
+      RichUrls.user_agent = 'test user agent'
+
+      expect(RichUrls.user_agent).to eq('test user agent')
+    end
   end
 end


### PR DESCRIPTION
Adds functionality to set a user agent for the Patron session. In some cases we need to adhere to a specific user agent in order to grab pages. By giving it a user agent some webpages on the internet might be a little bit more accepting.